### PR TITLE
Migrate to connectrpc and update dependencies

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,16 +2,16 @@ version: v1
 managed:
   enabled: true
 plugins:
-- plugin: buf.build/protocolbuffers/go:v1.30.0
+- plugin: buf.build/protocolbuffers/go:v1.31.0
   out: .
   opt: paths=source_relative
-- plugin: buf.build/bufbuild/connect-go:v1.7.0
+- plugin: buf.build/connectrpc/go:v1.11.0
   out: .
   opt: paths=source_relative
 
-- plugin: buf.build/bufbuild/connect-web:v0.8.6
+- plugin: buf.build/bufbuild/connect-es:v0.12.0
   out: .
   opt: target=js+dts
-- plugin: buf.build/bufbuild/es:v1.2.0
+- plugin: buf.build/bufbuild/es:v1.3.0
   out: .
   opt: target=js+dts

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module api.safer.place
 go 1.20
 
 require (
-	github.com/bufbuild/connect-go v1.7.0
-	google.golang.org/protobuf v1.30.0
+	connectrpc.com/connect v1.11.0
+	google.golang.org/protobuf v1.31.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
-github.com/bufbuild/connect-go v1.7.0 h1:MGp82v7SCza+3RhsVhV7aMikwxvI3ZfD72YiGt8FYJo=
-github.com/bufbuild/connect-go v1.7.0/go.mod h1:GmMJYR6orFqD0Y6ZgX8pwQ8j9baizDrIQMm1/a6LnHk=
+connectrpc.com/connect v1.11.0 h1:Av2KQXxSaX4vjqhf5Cl01SX4dqYADQ38eBtr84JSUBk=
+connectrpc.com/connect v1.11.0/go.mod h1:3AGaO6RRGMx5IKFfqbe3hvK1NqLosFNP2BxDYTPmNPo=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
-google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/internal/gomodkeep/gomodkeep.go
+++ b/internal/gomodkeep/gomodkeep.go
@@ -1,0 +1,7 @@
+// Package gomodkeep is designed to keep the required go modules imported
+package gomodkeep
+
+import (
+	_ "connectrpc.com/connect"
+	_ "google.golang.org/protobuf/proto"
+)


### PR DESCRIPTION
connect.build is now known as connectrpc. The change updates the
dependencies so that they use the latest generation methods.
