### PR TITLE
Use SaferPlace Github Actions as email alias

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -19,8 +19,8 @@ jobs:
           against: 'https://github.com/saferplace/api.git#branch=main'
       - name: Generate and Push
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name "SaferPlace Github Actions"
+          git config user.email github-actions@safer.place
           git switch generated
           git reset --hard main
           rm .gitignore


### PR DESCRIPTION
It looks like you can no longer use github-actions@github.com as the
commit author for the generated commits, so let's use an alias which is
within our control.
