### PR TITLE
review: Use full incident for IncidentsWithoutReview

### DIFF
--- a/review/v1/review.proto
+++ b/review/v1/review.proto
@@ -16,8 +16,7 @@ service ReviewService {
     rpc ViewIncident(ViewIncidentRequest) returns (ViewIncidentResponse);
     // ReviewIncident allows the client to send reviewed incident.
     rpc ReviewIncident(ReviewIncidentRequest) returns (ReviewIncidentResponse);
-    // IncidentsWithoutReview shows basic information about incidents which
-    // have not been reviewed yet.
+    // IncidentsWithoutReview returns all incidents which do not have a resolution yet.
     rpc IncidentsWithoutReview(IncidentsWithoutReviewRequest)
         returns (IncidentsWithoutReviewResponse);
 }
@@ -45,25 +44,13 @@ message ReviewIncidentRequest {
 }
 
 // ReviewIncidentResponse is empty
-message ReviewIncidentResponse {
-    
-}
+message ReviewIncidentResponse {}
 
 // IncidentsWithoutReviewRequest is send to see all the reviews which have
 // the resolution set as UNSPECIFIED
-message IncidentsWithoutReviewRequest {
+message IncidentsWithoutReviewRequest {}
 
-}
-
-// BasicIncidentDetails are send without are the bare minimum used to display
-// the incident.
-message BasicIncidentDetails {
-    string id = 1;
-    int64 timestamp = 2;
-    string description = 3;
-}
-
-// IncidentsWithoutReviewResponse contains the list of basic incident details
+// IncidentsWithoutReviewResponse contains the list of incidents which do not have a resolution.
 message IncidentsWithoutReviewResponse {
-    repeated BasicIncidentDetails incidents = 1;
+    repeated incident.v1.Incident incidents = 1;
 }


### PR DESCRIPTION
Converting to a basic incident details was pointless. We can send the
extra data as its not too big, and let the client deal with what it
wants to show.
