### PR TITLE
.github: Use Github Token with buf.build

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,6 +6,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ github.token }}
       - uses: bufbuild/buf-lint-action@v1
       # Disabled the breaking changes check before we have a stable v1 API.
       # - uses: bufbuild/buf-breaking-action@v1

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -13,6 +13,8 @@ jobs:
           ref: 'generated'
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ github.token }}
       - uses: bufbuild/buf-lint-action@v1
       - uses: bufbuild/buf-breaking-action@v1
         with:


### PR DESCRIPTION
Some of recent failures were due to API rate limits due to lack of the
github token specified.
